### PR TITLE
Thread pings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build
 run
 bot_logs/
 
+out/

--- a/src/main/java/net/neoforged/camelot/commands/utility/ThreadPingsCommand.java
+++ b/src/main/java/net/neoforged/camelot/commands/utility/ThreadPingsCommand.java
@@ -1,0 +1,261 @@
+package net.neoforged.camelot.commands.utility;
+
+import com.jagrosh.jdautilities.command.SlashCommand;
+import com.jagrosh.jdautilities.command.SlashCommandEvent;
+import net.dv8tion.jda.api.entities.IMentionable;
+import net.dv8tion.jda.api.entities.ISnowflake;
+import net.dv8tion.jda.api.entities.Role;
+import net.dv8tion.jda.api.entities.channel.attribute.IThreadContainer;
+import net.dv8tion.jda.api.entities.channel.middleman.GuildChannel;
+import net.dv8tion.jda.api.entities.channel.middleman.StandardGuildChannel;
+import net.dv8tion.jda.api.entities.channel.unions.GuildChannelUnion;
+import net.dv8tion.jda.api.events.GenericEvent;
+import net.dv8tion.jda.api.events.interaction.component.EntitySelectInteractionEvent;
+import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.SlashCommandInteraction;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
+import net.dv8tion.jda.api.interactions.components.ActionRow;
+import net.dv8tion.jda.api.interactions.components.selections.EntitySelectMenu;
+import net.dv8tion.jda.api.interactions.components.selections.EntitySelectMenu.SelectTarget;
+import net.dv8tion.jda.api.interactions.components.selections.SelectMenu;
+import net.dv8tion.jda.api.utils.MiscUtil;
+import net.neoforged.camelot.Database;
+import net.neoforged.camelot.db.transactionals.ThreadPingsDAO;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public class ThreadPingsCommand extends SlashCommand {
+    private static final String SELECT_MENU_ID_PREFIX = "thread-pings-configure-";
+
+    public ThreadPingsCommand() {
+        this.name = "thread-pings";
+        this.guildOnly = true;
+        this.children = new SlashCommand[]{
+                new ConfigureChannel(),
+                new ConfigureGuild(),
+                new View(),
+        };
+    }
+
+    @Override
+    protected void execute(SlashCommandEvent event) {
+    }
+
+    public static void onEvent(final GenericEvent gevent) {
+        if (!(gevent instanceof EntitySelectInteractionEvent event)) return;
+        assert event.getGuild() != null;
+
+        final String componentId = event.getComponentId();
+        if (!componentId.startsWith(SELECT_MENU_ID_PREFIX)) return;
+
+        final long channelId = MiscUtil.parseSnowflake(componentId.replace(SELECT_MENU_ID_PREFIX, ""));
+        boolean isGuildId = channelId == event.getGuild().getIdLong();
+
+        final GuildChannel channel = event.getJDA().getGuildChannelById(channelId);
+        if (!isGuildId && channel == null) {
+            // TODO: handle this?
+            return;
+        }
+
+        final List<Role> roles = event.getInteraction().getMentions().getRoles();
+        final List<Long> roleIds = roles
+                .stream()
+                .filter(c -> c.getGuild().equals(event.getGuild())) // In case roles from other guilds are included
+                .map(ISnowflake::getIdLong)
+                .toList();
+
+        Database.pings().useExtension(ThreadPingsDAO.class, threadPings -> {
+            final List<Long> existingRoles = threadPings.query(channelId);
+
+            for (Long existingRoleId : existingRoles) {
+                if (!roleIds.contains(existingRoleId)) {
+                    threadPings.remove(channelId, existingRoleId);
+                }
+            }
+
+            for (Long roleId : roleIds) {
+                if (!existingRoles.contains(roleId)) {
+                    threadPings.add(channelId, roleId);
+                }
+            }
+        });
+
+        event.getInteraction().editMessage(buildMessage(isGuildId ? "this guild" : channel.getAsMention(), roles)).queue();
+    }
+
+    public static class ConfigureChannel extends SlashCommand {
+        public ConfigureChannel() {
+            this.name = "configure-channel";
+            this.help = "Configure roles to be pinged in threads made under a channel";
+            this.options = List.of(
+                    new OptionData(OptionType.CHANNEL, "channel", "The channel", true)
+            );
+        }
+
+        @Override
+        protected void execute(SlashCommandEvent event) {
+            final CommonResult result = executeCommon(event);
+            if (result == null) return;
+            result.interaction.getHook().editOriginal(buildMessage(result.channel.getAsMention(), result.roles))
+                    .setComponents(ActionRow.of(
+                            EntitySelectMenu.create(SELECT_MENU_ID_PREFIX + result.channel.getId(), SelectTarget.ROLE)
+                                    .setMinValues(0)
+                                    .setMaxValues(SelectMenu.OPTIONS_MAX_AMOUNT)
+                                    .build()
+                    ))
+                    .queue();
+        }
+    }
+
+    public static class ConfigureGuild extends SlashCommand {
+        private static final String SELECT_MENU_ID_PREFIX = "thread-pings-configure-";
+
+        public ConfigureGuild() {
+            this.name = "configure-guild";
+            this.help = "Configure roles to be pinged in threads made under this guild";
+        }
+
+        @Override
+        protected void execute(SlashCommandEvent event) {
+            event.getInteraction().deferReply(true).queue();
+            assert event.getGuild() != null;
+            final long guildId = event.getGuild().getIdLong();
+
+            final List<Role> roles = Database.pings().withExtension(ThreadPingsDAO.class,
+                            threadPings -> threadPings.query(guildId))
+                    .stream()
+                    .map(id -> event.getJDA().getRoleById(id))
+                    .filter(Objects::nonNull)
+                    .toList();
+
+            event.getInteraction().getHook().editOriginal(buildMessage("this guild", roles))
+                    .setComponents(ActionRow.of(
+                            EntitySelectMenu.create(SELECT_MENU_ID_PREFIX + guildId, SelectTarget.ROLE)
+                                    .setMinValues(0)
+                                    .setMaxValues(SelectMenu.OPTIONS_MAX_AMOUNT)
+                                    .build()
+                    ))
+                    .queue();
+        }
+    }
+
+    public static class View extends SlashCommand {
+        public View() {
+            this.name = "view";
+            this.help = "View  roles to be pinged in threads made under a channel";
+            this.options = List.of(
+                    new OptionData(OptionType.CHANNEL, "channel", "The channel", true)
+            );
+        }
+
+        @Override
+        protected void execute(SlashCommandEvent event) {
+            final CommonResult result = executeCommon(event);
+            if (result == null) return;
+
+            boolean hasRoles = false;
+            final StringBuilder builder = new StringBuilder();
+
+            builder.append("The following roles are configured to be mentioned in threads public created under **")
+                    .append(result.channel.getAsMention())
+                    .append("**, along with the level of configuration:")
+                    .append('\n').append('\n');
+
+            if (!result.roles.isEmpty()) {
+                builder.append("__Channel ")
+                        .append(result.channel.getAsMention())
+                        .append(":__\n")
+                        .append(result.roles.stream().map(IMentionable::getAsMention).collect(Collectors.joining(", ")))
+                        .append('\n')
+                        .append('\n');
+                hasRoles = true;
+            }
+
+            if (result.channel instanceof StandardGuildChannel guildChannel && guildChannel.getParentCategory() != null) {
+                final var parentCategory = guildChannel.getParentCategory();
+                final List<Role> categoryRoles = Database.pings().withExtension(ThreadPingsDAO.class,
+                                threadPings -> threadPings.query(parentCategory.getIdLong()))
+                        .stream()
+                        .map(id -> event.getJDA().getRoleById(id))
+                        .filter(Objects::nonNull)
+                        .toList();
+
+                if (!categoryRoles.isEmpty()) {
+                    builder.append("__Parent category ")
+                            .append(parentCategory.getAsMention())
+                            .append(":__\n")
+                            .append(categoryRoles.stream().map(IMentionable::getAsMention).collect(Collectors.joining(", ")))
+                            .append('\n')
+                            .append('\n');
+                    hasRoles = true;
+                }
+            }
+
+            final List<Role> guildRoles = Database.pings().withExtension(ThreadPingsDAO.class,
+                            threadPings -> threadPings.query(result.channel.getGuild().getIdLong()))
+                    .stream()
+                    .map(id -> event.getJDA().getRoleById(id))
+                    .filter(Objects::nonNull)
+                    .toList();
+            if (!guildRoles.isEmpty()) {
+                builder.append("__Guild-wide:__\n")
+                        .append(guildRoles.stream().map(IMentionable::getAsMention).collect(Collectors.joining(", ")))
+                        .append('\n')
+                        .append('\n');
+                hasRoles = true;
+            }
+
+            if (!hasRoles) {
+                builder.setLength(0);
+                builder.trimToSize();
+                builder.append("No roles are configured to be mentioned for public threads created under this channel, category, or guild.");
+            }
+
+            result.interaction.getHook().editOriginal(builder.toString()).queue();
+        }
+    }
+
+    private static CommonResult executeCommon(SlashCommandEvent event) {
+        event.getInteraction().deferReply(true).queue();
+        final @Nullable GuildChannelUnion channel = event.getOption("channel", OptionMapping::getAsChannel);
+        assert channel != null;
+
+        if (!(channel instanceof IThreadContainer || channel instanceof net.dv8tion.jda.api.entities.channel.concrete.Category)) {
+            event.getInteraction().getHook().editOriginal(channel.getAsMention() + " cannot hold threads and is not a category!")
+                    .queue();
+            return null;
+        }
+
+        final List<Role> roles = Database.pings().withExtension(ThreadPingsDAO.class,
+                        threadPings -> threadPings.query(channel.getIdLong()))
+                .stream()
+                .map(id -> event.getJDA().getRoleById(id))
+                .filter(Objects::nonNull)
+                .toList();
+
+        return new CommonResult(event.getInteraction(), channel, roles);
+    }
+
+    record CommonResult(SlashCommandInteraction interaction, GuildChannelUnion channel, List<Role> roles) {
+    }
+
+    private static String buildMessage(String underText, List<? extends IMentionable> roles) {
+        final StringBuilder builder = new StringBuilder();
+
+        builder.append("The following roles will be mentioned in public threads created under ")
+                .append(underText)
+                .append(":\n");
+
+        if (roles.isEmpty()) {
+            builder.append("_None._");
+        } else {
+            builder.append(roles.stream().map(IMentionable::getAsMention).collect(Collectors.joining(", ")));
+        }
+
+        return builder.toString();
+    }
+}

--- a/src/main/java/net/neoforged/camelot/commands/utility/ThreadPingsCommand.java
+++ b/src/main/java/net/neoforged/camelot/commands/utility/ThreadPingsCommand.java
@@ -23,12 +23,15 @@ import net.dv8tion.jda.api.utils.MiscUtil;
 import net.neoforged.camelot.Database;
 import net.neoforged.camelot.db.transactionals.ThreadPingsDAO;
 import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
 public class ThreadPingsCommand extends SlashCommand {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ThreadPingsCommand.class);
     private static final String SELECT_MENU_ID_PREFIX = "thread-pings-configure-";
 
     public ThreadPingsCommand() {
@@ -57,7 +60,8 @@ public class ThreadPingsCommand extends SlashCommand {
 
         final GuildChannel channel = event.getJDA().getGuildChannelById(channelId);
         if (!isGuildId && channel == null) {
-            // TODO: handle this?
+            LOGGER.info("Received interaction for non-existent channel {}; deleting associated pings from database", channelId);
+            Database.pings().useExtension(ThreadPingsDAO.class, threadPings -> threadPings.clearChannel(channelId));
             return;
         }
 

--- a/src/main/java/net/neoforged/camelot/commands/utility/ThreadPingsCommand.java
+++ b/src/main/java/net/neoforged/camelot/commands/utility/ThreadPingsCommand.java
@@ -41,7 +41,6 @@ public class ThreadPingsCommand extends InteractiveCommand {
                 new ConfigureGuild(),
                 new View(),
         };
-        this.baseComponentId = "thread-pings";
     }
 
     @Override

--- a/src/main/java/net/neoforged/camelot/db/transactionals/ThreadPingsDAO.java
+++ b/src/main/java/net/neoforged/camelot/db/transactionals/ThreadPingsDAO.java
@@ -1,0 +1,29 @@
+package net.neoforged.camelot.db.transactionals;
+
+import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
+import org.jdbi.v3.sqlobject.statement.SqlUpdate;
+import org.jdbi.v3.sqlobject.transaction.Transactional;
+
+import java.util.List;
+
+// TODO: docs all the things
+public interface ThreadPingsDAO extends Transactional<ThreadPingsDAO> {
+
+    // Associate channel with role
+    @SqlUpdate("insert into thread_pings(channel, role) values (:channel, :role)")
+    void add(@Bind("channel") long channel, @Bind("role") long role);
+
+    // Delete association of channel to role
+    @SqlUpdate("delete from thread_pings where channel = :channel and role = :role")
+    void remove(@Bind("channel") long channel, @Bind("role") long role);
+
+    // Delete all roles from channel
+    @SqlUpdate("delete from thread_pings where channel = :channel")
+    void clear(@Bind("channel") long channel);
+
+    // Fetch roles associated with channel
+    @SqlQuery("select role from thread_pings where channel = :channel")
+    List<Long> query(@Bind("channel") long channel);
+
+}

--- a/src/main/java/net/neoforged/camelot/db/transactionals/ThreadPingsDAO.java
+++ b/src/main/java/net/neoforged/camelot/db/transactionals/ThreadPingsDAO.java
@@ -46,6 +46,14 @@ public interface ThreadPingsDAO extends Transactional<ThreadPingsDAO> {
     void clearChannel(@Bind("channel") long channel);
 
     /**
+     * Clears a role ID from all associations.
+     *
+     * @param role the role ID
+     */
+    @SqlUpdate("delete from thread_pings where role = :role")
+    void clearRole(@Bind("role") long role);
+
+    /**
      * {@return a list of role IDs associated with the given channel ID}
      *
      * @param channel the channel ID

--- a/src/main/java/net/neoforged/camelot/db/transactionals/ThreadPingsDAO.java
+++ b/src/main/java/net/neoforged/camelot/db/transactionals/ThreadPingsDAO.java
@@ -1,5 +1,6 @@
 package net.neoforged.camelot.db.transactionals;
 
+import net.dv8tion.jda.api.entities.Role;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
@@ -7,22 +8,48 @@ import org.jdbi.v3.sqlobject.transaction.Transactional;
 
 import java.util.List;
 
-// TODO: docs all the things
+/**
+ * Transactional used to interact with thread pings.
+ *
+ * <p>A thread ping is stored as a tuple of a channel ID and a role ID, which are both Discord snowflakes.</p>
+ *
+ * <p>Contrary to its name, the channel ID may either be an ID for a guild channel, or the ID of the guild for
+ * representing a thread ping for all public threads made in the guild. This second meaning is similar to how the
+ * {@linkplain Role#isPublicRole() public role}'s ID is the ID of the guild.</p>
+ */
 public interface ThreadPingsDAO extends Transactional<ThreadPingsDAO> {
 
-    // Associate channel with role
+    /**
+     * Associates a role ID with a channel ID.
+     *
+     * @param channel the channel ID
+     * @param role    the role ID
+     */
     @SqlUpdate("insert into thread_pings(channel, role) values (:channel, :role)")
     void add(@Bind("channel") long channel, @Bind("role") long role);
 
-    // Delete association of channel to role
+    /**
+     * Removes a role ID from being associated with a channel ID.
+     *
+     * @param channel the channel ID
+     * @param role    the role ID
+     */
     @SqlUpdate("delete from thread_pings where channel = :channel and role = :role")
     void remove(@Bind("channel") long channel, @Bind("role") long role);
 
-    // Delete all roles from channel
+    /**
+     * Clears all role IDs associated with the given channel ID.
+     *
+     * @param channel the channel ID
+     */
     @SqlUpdate("delete from thread_pings where channel = :channel")
-    void clear(@Bind("channel") long channel);
+    void clearChannel(@Bind("channel") long channel);
 
-    // Fetch roles associated with channel
+    /**
+     * {@return a list of role IDs associated with the given channel ID}
+     *
+     * @param channel the channel ID
+     */
     @SqlQuery("select role from thread_pings where channel = :channel")
     List<Long> query(@Bind("channel") long channel);
 

--- a/src/main/java/net/neoforged/camelot/listener/ThreadPingsListener.java
+++ b/src/main/java/net/neoforged/camelot/listener/ThreadPingsListener.java
@@ -15,6 +15,8 @@ import net.dv8tion.jda.api.hooks.EventListener;
 import net.neoforged.camelot.Database;
 import net.neoforged.camelot.db.transactionals.ThreadPingsDAO;
 import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -23,6 +25,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 public class ThreadPingsListener implements EventListener {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ThreadPingsListener.class);
+
     @Override
     public void onEvent(@NotNull GenericEvent gevent) {
         if (!(gevent instanceof ChannelCreateEvent event)) return;
@@ -54,7 +58,8 @@ public class ThreadPingsListener implements EventListener {
         for (Long roleId : roleIds) {
             final Role role = thread.getGuild().getRoleCache().getElementById(roleId);
             if (role == null) {
-                // TODO: log, maybe delete from DB
+                LOGGER.info("Role {} does not exist; deleting role from database", roleId);
+                Database.pings().useExtension(ThreadPingsDAO.class, threadPings -> threadPings.clearRole(roleId));
                 continue;
             }
             roles.add(role);

--- a/src/main/java/net/neoforged/camelot/listener/ThreadPingsListener.java
+++ b/src/main/java/net/neoforged/camelot/listener/ThreadPingsListener.java
@@ -1,5 +1,6 @@
 package net.neoforged.camelot.listener;
 
+import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.IMentionable;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.Message.MentionType;
@@ -72,6 +73,10 @@ public class ThreadPingsListener implements EventListener {
                 .map(IMentionable::getAsMention)
                 .collect(Collectors.joining(", ", "Hello to ", "!"));
 
+        if (!event.getGuild().getSelfMember().hasPermission(thread, Permission.MESSAGE_MENTION_EVERYONE)) {
+            LOGGER.warn("Bot user lacks Mention Everyone permission for thread {}; role adding may not work properly", thread.getId());
+        }
+
         thread.sendMessage("A new thread! Adding some people into here...")
                 .setSuppressedNotifications(true)
                 .setAllowedMentions(Set.of(MentionType.ROLE))
@@ -88,6 +93,5 @@ public class ThreadPingsListener implements EventListener {
                         .handle(Set.of(ErrorResponse.MESSAGE_BLOCKED_BY_AUTOMOD, ErrorResponse.MESSAGE_BLOCKED_BY_HARMFUL_LINK_FILTER),
                                 err -> LOGGER.warn("Got auto-blocked while trying to send thread ping message", err))
                 );
-
     }
 }

--- a/src/main/java/net/neoforged/camelot/listener/ThreadPingsListener.java
+++ b/src/main/java/net/neoforged/camelot/listener/ThreadPingsListener.java
@@ -59,7 +59,7 @@ public class ThreadPingsListener implements EventListener {
 
         final List<Role> roles = new ArrayList<>();
         for (Long roleId : roleIds) {
-            final Role role = thread.getGuild().getRoleCache().getElementById(roleId);
+            final Role role = thread.getGuild().getRoleById(roleId);
             if (role == null) {
                 LOGGER.info("Role {} does not exist; deleting role from database", roleId);
                 Database.pings().useExtension(ThreadPingsDAO.class, threadPings -> threadPings.clearRole(roleId));

--- a/src/main/java/net/neoforged/camelot/listener/ThreadPingsListener.java
+++ b/src/main/java/net/neoforged/camelot/listener/ThreadPingsListener.java
@@ -1,0 +1,78 @@
+package net.neoforged.camelot.listener;
+
+import net.dv8tion.jda.api.entities.IMentionable;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.Message.MentionType;
+import net.dv8tion.jda.api.entities.Role;
+import net.dv8tion.jda.api.entities.channel.ChannelType;
+import net.dv8tion.jda.api.entities.channel.concrete.Category;
+import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel;
+import net.dv8tion.jda.api.entities.channel.middleman.StandardGuildChannel;
+import net.dv8tion.jda.api.entities.channel.unions.IThreadContainerUnion;
+import net.dv8tion.jda.api.events.GenericEvent;
+import net.dv8tion.jda.api.events.channel.ChannelCreateEvent;
+import net.dv8tion.jda.api.hooks.EventListener;
+import net.neoforged.camelot.Database;
+import net.neoforged.camelot.db.transactionals.ThreadPingsDAO;
+import org.jetbrains.annotations.NotNull;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class ThreadPingsListener implements EventListener {
+    @Override
+    public void onEvent(@NotNull GenericEvent gevent) {
+        if (!(gevent instanceof ChannelCreateEvent event)) return;
+        // We don't care about private threads (managed manually by moderators/owner) or news/announcement threads (all
+        // users who can see the channel are added automatically)
+        if (!(event.isFromType(ChannelType.GUILD_PUBLIC_THREAD)))
+            return;
+
+        final ThreadChannel thread = event.getChannel().asThreadChannel();
+        final List<Long> roleIds = new ArrayList<>();
+        Database.pings().useExtension(ThreadPingsDAO.class, threadPings -> {
+            // Check the thread's parent channel
+            final IThreadContainerUnion parentChannel = thread.getParentChannel();
+            roleIds.addAll(threadPings.query(parentChannel.getIdLong()));
+
+            if (parentChannel instanceof StandardGuildChannel guildChannel) {
+                // Check the category of the thread's parent channel
+                final Category parentCategory = guildChannel.getParentCategory();
+                if (parentCategory != null) {
+                    roleIds.addAll(threadPings.query(parentCategory.getIdLong()));
+                }
+            }
+
+            // Check guild-wide (using the guild ID)
+            roleIds.addAll(threadPings.query(thread.getGuild().getIdLong()));
+        });
+
+        final List<Role> roles = new ArrayList<>();
+        for (Long roleId : roleIds) {
+            final Role role = thread.getGuild().getRoleCache().getElementById(roleId);
+            if (role == null) {
+                // TODO: log, maybe delete from DB
+                continue;
+            }
+            roles.add(role);
+        }
+
+        if (roles.isEmpty()) return;
+        final String mentionMessage = roles.stream()
+                .map(IMentionable::getAsMention)
+                .collect(Collectors.joining(", ", "Hello to ", "!"));
+
+        thread.sendMessage("A new thread! Adding some people into here...")
+                .setSuppressedNotifications(true)
+                .setAllowedMentions(Set.of(MentionType.ROLE))
+                .delay(Duration.ofSeconds(3))
+                .flatMap(message -> message.editMessage(message.getContentRaw() + '\n' + mentionMessage))
+                .delay(Duration.ofSeconds(3))
+                .flatMap(Message::delete)
+                .queue();
+        // TODO: error handling (e.g. unable to send message)
+    }
+}

--- a/src/main/java/net/neoforged/camelot/module/ThreadPingsModule.java
+++ b/src/main/java/net/neoforged/camelot/module/ThreadPingsModule.java
@@ -1,0 +1,26 @@
+package net.neoforged.camelot.module;
+
+import com.google.auto.service.AutoService;
+import com.jagrosh.jdautilities.command.CommandClientBuilder;
+import net.dv8tion.jda.api.JDABuilder;
+import net.dv8tion.jda.api.hooks.EventListener;
+import net.neoforged.camelot.commands.utility.ThreadPingsCommand;
+import net.neoforged.camelot.listener.ThreadPingsListener;
+
+@AutoService(CamelotModule.class)
+public class ThreadPingsModule implements CamelotModule {
+    @Override
+    public String id() {
+        return "threadPings";
+    }
+
+    @Override
+    public void registerCommands(CommandClientBuilder builder) {
+        builder.addSlashCommand(new ThreadPingsCommand());
+    }
+
+    @Override
+    public void registerListeners(JDABuilder builder) {
+        builder.addEventListeners(new ThreadPingsListener(), (EventListener) ThreadPingsCommand::onEvent);
+    }
+}

--- a/src/main/java/net/neoforged/camelot/module/ThreadPingsModule.java
+++ b/src/main/java/net/neoforged/camelot/module/ThreadPingsModule.java
@@ -7,6 +7,14 @@ import net.dv8tion.jda.api.hooks.EventListener;
 import net.neoforged.camelot.commands.utility.ThreadPingsCommand;
 import net.neoforged.camelot.listener.ThreadPingsListener;
 
+/**
+ * Module for thread pings, for automatically mentioning a role in public threads created under a channel and
+ * therefore adding all holders of the role to that thread.
+ *
+ * @see ThreadPingsCommand
+ * @see ThreadPingsListener
+ * @see net.neoforged.camelot.db.transactionals.ThreadPingsDAO
+ */
 @AutoService(CamelotModule.class)
 public class ThreadPingsModule implements CamelotModule {
     @Override

--- a/src/main/java/net/neoforged/camelot/module/ThreadPingsModule.java
+++ b/src/main/java/net/neoforged/camelot/module/ThreadPingsModule.java
@@ -3,7 +3,6 @@ package net.neoforged.camelot.module;
 import com.google.auto.service.AutoService;
 import com.jagrosh.jdautilities.command.CommandClientBuilder;
 import net.dv8tion.jda.api.JDABuilder;
-import net.dv8tion.jda.api.hooks.EventListener;
 import net.neoforged.camelot.commands.utility.ThreadPingsCommand;
 import net.neoforged.camelot.listener.ThreadPingsListener;
 
@@ -29,6 +28,6 @@ public class ThreadPingsModule implements CamelotModule {
 
     @Override
     public void registerListeners(JDABuilder builder) {
-        builder.addEventListeners(new ThreadPingsListener(), (EventListener) ThreadPingsCommand::onEvent);
+        builder.addEventListeners(new ThreadPingsListener());
     }
 }

--- a/src/main/resources/db/pings/V2__thread_pings.sql
+++ b/src/main/resources/db/pings/V2__thread_pings.sql
@@ -1,0 +1,6 @@
+create table thread_pings
+(
+    channel unsigned big int not null,
+    role    unsigned big int not null,
+    constraint thread_pings_pk primary key (channel, role)
+);


### PR DESCRIPTION
This PR adds a new feature called **thread pings**, which automatically mentions roles in public threads created under certain channels, certain categories, or guild-wide, to add them to the thread without requiring those users to manually join it.

This is useful for moderators to keep track of every thread made in the guild, or some group of users to be apprised of every thread in a forum or text channel.

There are three commands: 
- `/thread-ping view <channel>`, which lists out all roles which will be automatically mentioned when a thread is created in a given channel or category;
- `/thread-ping configure-channel <channel>`, to configure what roles will be automatically mentiond when a thread is created in a given channel or category; and
- `/thread-ping configure-guild`, to configure what roles will be automatically mentioned when a thread is created in this guild.