### PR TITLE
Add optional embed for promoted tricks on prefix invocation.

### DIFF
--- a/src/main/java/net/neoforged/camelot/configuration/Config.java
+++ b/src/main/java/net/neoforged/camelot/configuration/Config.java
@@ -59,6 +59,11 @@ public class Config {
     public static boolean PROMOTED_SLASH_ONLY = false;
 
     /**
+     * If {@code true}, prefix command invocations of promoted tricks tell the user they should prefer the slash variant.
+     */
+    public static boolean ENCOURAGE_PROMOTED_SLASH = false;
+
+    /**
      * A {@link GitHub} instance used for creating file preview gists.
      */
     public static GitHub FILE_PREVIEW_GISTS;
@@ -81,6 +86,7 @@ public class Config {
             TRICK_MASTER_ROLE = Long.parseLong(properties.getProperty("trick.master", properties.getProperty("trickMaster", "0")));
             PREFIX_TRICKS = Boolean.parseBoolean(properties.getProperty("tricks.prefix", properties.getProperty("prefixTricks", "true")));
             PROMOTED_SLASH_ONLY = Boolean.parseBoolean(properties.getProperty("tricks.promotedSlashOnly", "false"));
+            ENCOURAGE_PROMOTED_SLASH = Boolean.parseBoolean(properties.getProperty("tricks.encouragePromotedSlash", "false"));
         } catch (Exception e) {
             Files.writeString(Path.of("config.properties"),
                     """
@@ -99,6 +105,8 @@ public class Config {
                             tricks.prefix=true
                             # If true, promoted tricks can only be invoked via the slash variant.
                             tricks.promotedSlashOnly=false
+                            # If true, prefix command invocations of promoted tricks tell the user they should prefer the slash variant.
+                            tricks.encouragePromotedSlash=false
                             
                             # The channel in which to send moderation logs.
                             moderationLogs=0

--- a/src/main/java/net/neoforged/camelot/listener/TrickListener.java
+++ b/src/main/java/net/neoforged/camelot/listener/TrickListener.java
@@ -79,6 +79,7 @@ public record TrickListener(String prefix) implements EventListener {
                                     //noinspection resource
                                     createData = MessageCreateBuilder.from(createData)
                                                                      .addEmbeds(new EmbedBuilder().setDescription("That trick is promoted. Consider using " + asSlash.getAsMention() + " instead.")
+                                                                                                  .setColor(0x2F3136)
                                                                                                   .build())
                                                                      .build();
                                 }

--- a/src/main/java/net/neoforged/camelot/listener/TrickListener.java
+++ b/src/main/java/net/neoforged/camelot/listener/TrickListener.java
@@ -1,11 +1,14 @@
 package net.neoforged.camelot.listener;
 
+import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.events.GenericEvent;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.hooks.EventListener;
 import net.dv8tion.jda.api.interactions.commands.Command;
 import net.dv8tion.jda.api.requests.RestAction;
+import net.dv8tion.jda.api.utils.messages.MessageCreateBuilder;
 import net.dv8tion.jda.api.utils.messages.MessageCreateData;
 import net.dv8tion.jda.api.utils.messages.MessageEditData;
 import net.neoforged.camelot.BotMain;
@@ -66,6 +69,21 @@ public record TrickListener(String prefix) implements EventListener {
                 @Override
                 protected RestAction<?> doSend(MessageCreateData createData) {
                     synchronized (this) {
+                        if (Config.ENCOURAGE_PROMOTED_SLASH) {
+                            final SlashTrick promotion = Database.main().withExtension(SlashTricksDAO.class, db -> db.getPromotion(trick.id(), event.getGuild().getIdLong()));
+                            if (promotion != null) {
+                                final Command.Subcommand asSlash = BotMain.getModule(TricksModule.class)
+                                        .slashTrickManagers.get(event.getGuild().getIdLong())
+                                                           .getByName(promotion.getFullName());
+                                if (asSlash != null && createData.getEmbeds().size() < 10) {
+                                    //noinspection resource
+                                    createData = MessageCreateBuilder.from(createData)
+                                                                     .addEmbeds(new EmbedBuilder().setDescription("That trick is promoted. Consider using " + asSlash.getAsMention() + " instead.")
+                                                                                                  .build())
+                                                                     .build();
+                                }
+                            }
+                        }
                         if (reply == null) {
                             return event.getMessage().reply(createData)
                                     .setAllowedMentions(ALLOWED_MENTIONS)


### PR DESCRIPTION
This PR adds a config option to add an extra embed to the end of trick results if said trick was invoked via prefix commands and has a slash command variant.
This embed tells the user that they should prefer using the slash command instead while not completely disabling prefix commands.