### PR TITLE
make the quote attributions normal hyphens again

### DIFF
--- a/src/main/java/net/neoforged/camelot/commands/information/QuoteCommand.java
+++ b/src/main/java/net/neoforged/camelot/commands/information/QuoteCommand.java
@@ -78,7 +78,7 @@ public class QuoteCommand extends SlashCommand {
         event.getMessage().reply(STR. """
             #\{ quote.id() }
             > \{ quote.quote() }
-            - \{ quote.createAuthor() }
+            \- \{ quote.createAuthor() }
             """ .trim()).mentionRepliedUser(false).setAllowedMentions(List.of()).queue();
     }
 
@@ -110,7 +110,7 @@ public class QuoteCommand extends SlashCommand {
             event.reply(STR. """
             #\{ quote.id() }
             > \{ quote.quote() }
-            - \{ quote.createAuthor() }
+            \- \{ quote.createAuthor() }
             """ .trim()).setAllowedMentions(List.of()).queue();
         }
     }

--- a/src/main/java/net/neoforged/camelot/commands/information/QuoteCommand.java
+++ b/src/main/java/net/neoforged/camelot/commands/information/QuoteCommand.java
@@ -78,7 +78,7 @@ public class QuoteCommand extends SlashCommand {
         event.getMessage().reply(STR. """
             #\{ quote.id() }
             > \{ quote.quote() }
-            \- \{ quote.createAuthor() }
+            \\- \{ quote.createAuthor() }
             """ .trim()).mentionRepliedUser(false).setAllowedMentions(List.of()).queue();
     }
 
@@ -110,7 +110,7 @@ public class QuoteCommand extends SlashCommand {
             event.reply(STR. """
             #\{ quote.id() }
             > \{ quote.quote() }
-            \- \{ quote.createAuthor() }
+            \\- \{ quote.createAuthor() }
             """ .trim()).setAllowedMentions(List.of()).queue();
         }
     }


### PR DESCRIPTION
Pretty self-explanatory, I think. Changes the quote attribution to be a regular hyphen instead of a markdown bullet point, like it was before markdown lists were introduced in Discord.