### PR TITLE
Implement role exemptions for thread pings

### DIFF
--- a/docs/docs/.vitepress/config.js
+++ b/docs/docs/.vitepress/config.js
@@ -43,6 +43,10 @@ export default {
                         text: 'Sticky Roles',
                         link: '/modules/sticky-roles'
                     },
+                    {
+                        text: 'Thread Pings',
+                        link: '/modules/thread-pings'
+                    }
                 ]
             }
         ],

--- a/docs/docs/modules/index.md
+++ b/docs/docs/modules/index.md
@@ -14,5 +14,5 @@ By default, the following modules are enabled:
 - Reminders
 - Statistics
 - [Sticky Roles](./sticky-roles)
-- Thread Pings
+- [Thread Pings](./thread-pings)
 - Tricks

--- a/docs/docs/modules/thread-pings.md
+++ b/docs/docs/modules/thread-pings.md
@@ -1,0 +1,36 @@
+# Thread Pings Module
+The thread pings module (id: `thread-pings`, configuration class: `ThreadPings`) allows for certain roles to be 
+automatically added to public threads created in specific channels, categories, or the server (a.k.a. the guild). The
+automatic addition is done in a way that doesn't send push notifications to the added users.
+
+The server, each category, and each channel can be configured with a list of roles to be added to public threads created
+within their scope. For categories and channels, roles can be configured to be exempted from being automatically added.
+
+The module provide three configuration commands:
+- The `/configuration thread-pings configure-guild` command provides an interface to configure thread pings for the 
+  entire guild/server.
+- The `/configuration thread-pings configure-channel` command provides an interface to configure thread pings for a 
+  specific channel, which may be a channel category.
+- The `/configuration thread-pings view` command, when given a channel, shows the current setup of roles for the channel, 
+  its parent category (if available), and the guild, including which roles will be automatically added and which are 
+  exempted.
+
+## Role Exemptions
+In certain situations, it would be useful to exempt previously-configured roles from being automatically added in 
+specific areas of the server. (For example, a highly active forum may want to not have all moderators always added, to 
+avoid flooding their channel list with many threads.)
+
+Roles can be exempted in categories and channels, which block those roles from being automatically added to a thread even
+if configured at a different level. (In the previous example: moderators may be configured to be added server-wide, but
+the forum channel can exempt the moderator role.)
+
+All role exemptions are **unconditionally applied after** all configured ping roles are considered. This means, for 
+example, that an exemption at the category level will still apply to a role even if it is explicitly configured for a
+channel within that category.
+
+## Bot Permissions
+The following bot permissions are required by this module: `View Channels`, `Send Messages`, `Send Messages in Threads` 
+and `Mention Everyone`.
+
+The bot may function without the `Mention Everyone` permission, but roles which are not globally mentionable/pingable may
+not be added to threads properly.

--- a/modules/thread-pings/src/main/java/net/neoforged/camelot/module/threadpings/ThreadPingsCommand.java
+++ b/modules/thread-pings/src/main/java/net/neoforged/camelot/module/threadpings/ThreadPingsCommand.java
@@ -33,7 +33,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.StringJoiner;
-import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.function.LongFunction;
 import java.util.stream.Collectors;
@@ -364,7 +363,7 @@ public abstract class ThreadPingsCommand extends InteractiveCommand {
     }
 
     private static void applyNewRoles(long channelId, List<Long> roleIds, LongFunction<List<Long>> query,
-                                      BiConsumer<Long, Long> adder, BiConsumer<Long, Long> remover) {
+                                      ChannelRoleConsumer adder, ChannelRoleConsumer remover) {
         final List<Long> existingRoles = query.apply(channelId);
 
         for (Long existingRoleId : existingRoles) {
@@ -378,5 +377,10 @@ public abstract class ThreadPingsCommand extends InteractiveCommand {
                 adder.accept(channelId, roleId);
             }
         }
+    }
+
+    @FunctionalInterface
+    private interface ChannelRoleConsumer {
+        void accept(long channelId, long roleId);
     }
 }

--- a/modules/thread-pings/src/main/java/net/neoforged/camelot/module/threadpings/ThreadPingsListener.java
+++ b/modules/thread-pings/src/main/java/net/neoforged/camelot/module/threadpings/ThreadPingsListener.java
@@ -25,6 +25,8 @@ import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.LongFunction;
@@ -42,11 +44,11 @@ public record ThreadPingsListener(Jdbi database) implements EventListener {
             return;
 
         final ThreadChannel thread = event.getChannel().asThreadChannel();
-        final List<Long> pingRoleIds = new ArrayList<>();
+        final Set<Long> pingRoleIds = new LinkedHashSet<>();
         database.useExtension(ThreadPingsDAO.class,
                 threadPings -> queryRoles(thread, pingRoleIds, threadPings::query));
 
-        final List<Long> exemptRoleIds = new ArrayList<>();
+        final Set<Long> exemptRoleIds = new LinkedHashSet<>();
 
         database.useExtension(ThreadPingsExemptionsDAO.class,
                 threadPingsExempt -> queryRoles(thread, exemptRoleIds, threadPingsExempt::query));
@@ -102,7 +104,7 @@ public record ThreadPingsListener(Jdbi database) implements EventListener {
                 );
     }
 
-    private static void queryRoles(ThreadChannel thread, List<Long> roleIds, LongFunction<List<Long>> roleQuery) {
+    private static void queryRoles(ThreadChannel thread, Collection<Long> roleIds, LongFunction<List<Long>> roleQuery) {
         // Check the thread's parent channel
         final IThreadContainerUnion parentChannel = thread.getParentChannel();
         roleIds.addAll(roleQuery.apply(parentChannel.getIdLong()));

--- a/modules/thread-pings/src/main/java/net/neoforged/camelot/module/threadpings/ThreadPingsListener.java
+++ b/modules/thread-pings/src/main/java/net/neoforged/camelot/module/threadpings/ThreadPingsListener.java
@@ -15,9 +15,8 @@ import net.dv8tion.jda.api.events.channel.ChannelCreateEvent;
 import net.dv8tion.jda.api.exceptions.ErrorHandler;
 import net.dv8tion.jda.api.hooks.EventListener;
 import net.dv8tion.jda.api.requests.ErrorResponse;
-import net.neoforged.camelot.BotMain;
-import net.neoforged.camelot.Database;
 import net.neoforged.camelot.module.threadpings.db.ThreadPingsDAO;
+import net.neoforged.camelot.module.threadpings.db.ThreadPingsExemptionsDAO;
 import net.neoforged.camelot.util.Emojis;
 import org.jdbi.v3.core.Jdbi;
 import org.jetbrains.annotations.NotNull;
@@ -28,6 +27,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.function.LongFunction;
 import java.util.stream.Collectors;
 
 public record ThreadPingsListener(Jdbi database) implements EventListener {
@@ -40,39 +40,43 @@ public record ThreadPingsListener(Jdbi database) implements EventListener {
         // users who can see the channel are added automatically)
         if (!(event.isFromType(ChannelType.GUILD_PUBLIC_THREAD)))
             return;
-        
+
         final ThreadChannel thread = event.getChannel().asThreadChannel();
-        final List<Long> roleIds = new ArrayList<>();
-        database.useExtension(ThreadPingsDAO.class, threadPings -> {
-            // Check the thread's parent channel
-            final IThreadContainerUnion parentChannel = thread.getParentChannel();
-            roleIds.addAll(threadPings.query(parentChannel.getIdLong()));
+        final List<Long> pingRoleIds = new ArrayList<>();
+        database.useExtension(ThreadPingsDAO.class,
+                threadPings -> queryRoles(thread, pingRoleIds, threadPings::query));
 
-            if (parentChannel instanceof StandardGuildChannel guildChannel) {
-                // Check the category of the thread's parent channel
-                final Category parentCategory = guildChannel.getParentCategory();
-                if (parentCategory != null) {
-                    roleIds.addAll(threadPings.query(parentCategory.getIdLong()));
-                }
-            }
+        final List<Long> exemptRoleIds = new ArrayList<>();
 
-            // Check guild-wide (using the guild ID)
-            roleIds.addAll(threadPings.query(thread.getGuild().getIdLong()));
-        });
+        database.useExtension(ThreadPingsExemptionsDAO.class,
+                threadPingsExempt -> queryRoles(thread, exemptRoleIds, threadPingsExempt::query));
 
-        final List<Role> roles = new ArrayList<>();
-        for (Long roleId : roleIds) {
+        final List<Role> pingRoles = new ArrayList<>();
+        for (Long roleId : pingRoleIds) {
             final Role role = thread.getGuild().getRoleById(roleId);
             if (role == null) {
-                LOGGER.info("Role {} does not exist; deleting role from database", roleId);
+                LOGGER.info("Ping role {} does not exist; deleting role from database", roleId);
                 database.useExtension(ThreadPingsDAO.class, threadPings -> threadPings.clearRole(roleId));
                 continue;
             }
-            roles.add(role);
+            pingRoles.add(role);
         }
 
-        if (roles.isEmpty()) return;
-        final String mentionMessage = roles.stream()
+        final List<Role> exemptRoles = new ArrayList<>();
+        for (Long roleId : exemptRoleIds) {
+            final Role role = thread.getGuild().getRoleById(roleId);
+            if (role == null) {
+                LOGGER.info("Exempt role {} does not exist; deleting role from database", roleId);
+                database.useExtension(ThreadPingsExemptionsDAO.class, threadPingsExempt -> threadPingsExempt.clearRole(roleId));
+                continue;
+            }
+            exemptRoles.add(role);
+        }
+
+        pingRoles.removeAll(exemptRoles);
+
+        if (pingRoles.isEmpty()) return;
+        final String mentionMessage = pingRoles.stream()
                 .map(IMentionable::getAsMention)
                 .collect(Collectors.joining(", ", "Hello to ", "!"));
 
@@ -96,5 +100,22 @@ public record ThreadPingsListener(Jdbi database) implements EventListener {
                         .handle(Set.of(ErrorResponse.MESSAGE_BLOCKED_BY_AUTOMOD, ErrorResponse.MESSAGE_BLOCKED_BY_HARMFUL_LINK_FILTER),
                                 err -> LOGGER.warn("Got auto-blocked while trying to send thread ping message", err))
                 );
+    }
+
+    private static void queryRoles(ThreadChannel thread, List<Long> roleIds, LongFunction<List<Long>> roleQuery) {
+        // Check the thread's parent channel
+        final IThreadContainerUnion parentChannel = thread.getParentChannel();
+        roleIds.addAll(roleQuery.apply(parentChannel.getIdLong()));
+
+        if (parentChannel instanceof StandardGuildChannel guildChannel) {
+            // Check the category of the thread's parent channel
+            final Category parentCategory = guildChannel.getParentCategory();
+            if (parentCategory != null) {
+                roleIds.addAll(roleQuery.apply(parentCategory.getIdLong()));
+            }
+        }
+
+        // Check guild-wide (using the guild ID)
+        roleIds.addAll(roleQuery.apply(thread.getGuild().getIdLong()));
     }
 }

--- a/modules/thread-pings/src/main/java/net/neoforged/camelot/module/threadpings/db/ThreadPingsExemptionsDAO.java
+++ b/modules/thread-pings/src/main/java/net/neoforged/camelot/module/threadpings/db/ThreadPingsExemptionsDAO.java
@@ -1,0 +1,63 @@
+package net.neoforged.camelot.module.threadpings.db;
+
+import net.dv8tion.jda.api.entities.Role;
+import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
+import org.jdbi.v3.sqlobject.statement.SqlUpdate;
+import org.jdbi.v3.sqlobject.transaction.Transactional;
+
+import java.util.List;
+
+/**
+ * Transactional used to interact with thread pings exemptions.
+ *
+ * <p>A thread ping exemption is stored as a tuple of a channel ID and a role ID, which are both Discord snowflakes.</p>
+ *
+ * <p>Contrary to its name, the channel ID may either be an ID for a guild channel, or the ID of the guild for
+ * representing a thread ping for all public threads made in the guild. This second meaning is similar to how the
+ * {@linkplain Role#isPublicRole() public role}'s ID is the ID of the guild.</p>
+ */
+public interface ThreadPingsExemptionsDAO extends Transactional<ThreadPingsExemptionsDAO> {
+
+    /**
+     * Associates a role ID with a channel ID.
+     *
+     * @param channel the channel ID
+     * @param role    the role ID
+     */
+    @SqlUpdate("insert into thread_pings_exemptions(channel, role) values (:channel, :role)")
+    void add(@Bind("channel") long channel, @Bind("role") long role);
+
+    /**
+     * Removes a role ID from being associated with a channel ID.
+     *
+     * @param channel the channel ID
+     * @param role    the role ID
+     */
+    @SqlUpdate("delete from thread_pings_exemptions where channel = :channel and role = :role")
+    void remove(@Bind("channel") long channel, @Bind("role") long role);
+
+    /**
+     * Clears all role IDs associated with the given channel ID.
+     *
+     * @param channel the channel ID
+     */
+    @SqlUpdate("delete from thread_pings_exemptions where channel = :channel")
+    void clearChannel(@Bind("channel") long channel);
+
+    /**
+     * Clears a role ID from all associations.
+     *
+     * @param role the role ID
+     */
+    @SqlUpdate("delete from thread_pings_exemptions where role = :role")
+    void clearRole(@Bind("role") long role);
+
+    /**
+     * {@return a list of role IDs associated with the given channel ID}
+     *
+     * @param channel the channel ID
+     */
+    @SqlQuery("select role from thread_pings_exemptions where channel = :channel")
+    List<Long> query(@Bind("channel") long channel);
+}

--- a/modules/thread-pings/src/main/resources/net/neoforged/camelot/module/threadpings/db/schema/V2__exemptions.sql
+++ b/modules/thread-pings/src/main/resources/net/neoforged/camelot/module/threadpings/db/schema/V2__exemptions.sql
@@ -1,0 +1,6 @@
+create table thread_pings_exemptions
+(
+    channel unsigned big int not null,
+    role    unsigned big int not null,
+    constraint thread_pings_exemptions_pk primary key (channel, role)
+);


### PR DESCRIPTION
This PR implements and closes #23 by adding thread pings role exemptions. See the linked issue for more details.

Aside from the implementation of the feature, there is one other bundled QoL change: the configuration commands for thread pings will auto-populate the select menu with the pre-existing configuration, instead of requiring the administrator to re-select every (unaffected) role anytime they wish to change it.